### PR TITLE
fix: `libunwind` missing symbols

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -555,7 +555,7 @@ config("runtime_library") {
     ]
 
     libs += [
-      # The Shorebird updater requires unwind.
+      # Rust requires libunwind.
       "unwind",
       "c",
       "dl",

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -555,6 +555,8 @@ config("runtime_library") {
     ]
 
     libs += [
+      # The Shorebird updater requires unwind.
+      "unwind",
       "c",
       "dl",
       "m",
@@ -569,6 +571,8 @@ config("runtime_library") {
     } else if (current_cpu == "x86") {
       current_android_cpu = "i686"
     }
+    # libunwind.a is located in the respective android cpu subdirectories.
+    lib_dirs += [ "${android_toolchain_root}/lib/clang/17/lib/linux/${current_android_cpu}/" ]
     libs += [ "clang_rt.builtins-${current_android_cpu}-android" ]
   }
 


### PR DESCRIPTION
`buildroot` was no longer adding the lib dir containing `libunwind.a` which is needed for the shorebird updater (tokio, backtrace, gcc.rs, etc.)

This adjusts the `BUILD.gn` to include `unwind` and adds the correct cpu-specific subdirectory in the android_tools ndk.