### PR TITLE
Add support for def files in windows linking

### DIFF
--- a/build/toolchain/win/BUILD.gn
+++ b/build/toolchain/win/BUILD.gn
@@ -201,8 +201,11 @@ template("msvc_toolchain") {
       expname = "${dllname}.exp"
       pdbname = "${dllname}.pdb"
       rspfile = "${dllname}.rsp"
+      # .def files are used to export symbols from the DLL. This arg will be
+      # removed by the python tool wrapper if the .def file doesn't exist.
+      deffile = "${dllname}.def"
 
-      link_command = "\"$python_path\" $tool_wrapper_path link-wrapper $env False link.exe /nologo /IMPLIB:$libname /DLL /OUT:$dllname /PDB:${dllname}.pdb @$rspfile"
+      link_command = "\"$python_path\" $tool_wrapper_path link-wrapper $env False link.exe /nologo /IMPLIB:$libname /DLL /OUT:$dllname /PDB:${dllname}.pdb /DEF:$deffile @$rspfile"
 
       # TODO(brettw) support manifests
       #manifest_command = "\"$python_path\" $tool_wrapper_path manifest-wrapper $env mt.exe -nologo -manifest $manifests -out:${dllname}.manifest"

--- a/build/toolchain/win/tool_wrapper.py
+++ b/build/toolchain/win/tool_wrapper.py
@@ -129,7 +129,7 @@ class WinTool(object):
       def_arg_prefix = "/DEF:"
       for arg in args:
         if arg.startswith(def_arg_prefix):
-          def_file = arg[len(def_arg_prefix) :]
+          def_file = arg[len(def_arg_prefix):]
           if not os.path.exists(def_file):
             args.remove(arg)
       args[0] = args[0].replace('/', '\\')

--- a/build/toolchain/win/tool_wrapper.py
+++ b/build/toolchain/win/tool_wrapper.py
@@ -121,6 +121,17 @@ class WinTool(object):
       self._UseSeparateMspdbsrv(env, args)
     if sys.platform == 'win32':
       args = list(args)  # *args is a tuple by default, which is read-only.
+
+      # Remove the /DEF arg if not provided. We would ideally be able to do this
+      # in build\toolchain\win\BUILD.gn, but there doesn't seem to be a way to
+      # conditionally add args to the command line based on whether a file exists
+      # or not, so we do it here instead.
+      def_arg_prefix = "/DEF:"
+      for arg in args:
+        if arg.startswith(def_arg_prefix):
+          def_file = arg[len(def_arg_prefix) :]
+          if not os.path.exists(def_file):
+            args.remove(arg)
       args[0] = args[0].replace('/', '\\')
     # https://docs.python.org/2/library/subprocess.html:
     # "On Unix with shell=True [...] if args is a sequence, the first item


### PR DESCRIPTION
This change allows us to provide .def files to export extra symbols in the dll produced by the link command

Part of https://github.com/shorebirdtech/shorebird/issues/2814